### PR TITLE
Updated Video Permission Levels

### DIFF
--- a/Source/ViddlerV2/Data/VideoPermissionLevel.cs
+++ b/Source/ViddlerV2/Data/VideoPermissionLevel.cs
@@ -20,15 +20,15 @@ namespace Viddler.Data
     [XmlEnum(Name = "private")]
     Private,
     /// <summary>
-    /// Corresponds to the remote Viddler API enumerated value "shared"
+    /// Corresponds to the remote Viddler API enumerated value "invite"
     /// </summary>
-    [XmlEnum(Name = "shared")]
-    Shared,
+    [XmlEnum(Name = "invite")]
+    Invite,
     /// <summary>
-    /// Corresponds to the remote Viddler API enumerated value "shared_all"
+    /// Corresponds to the remote Viddler API enumerated value "embed"
     /// </summary>
-    [XmlEnum(Name = "shared_all")]
-    SharedAll,
+    [XmlEnum(Name = "embed")]
+    Embed,
     /// <summary>
     /// Corresponds to the remote Viddler API enumerated value "public"
     /// </summary>


### PR DESCRIPTION
I just started using the API and the first issue I had was calling Videos.GetByUser().

Some of the videos were set to "Invitation only" (or "invite") and there was no enum for this in the VideoPermissionLevel enum. This caused an exception during xml deserialization. I just updated this enum to match what I could find online in the [API docs](http://developers.viddler.com/documentation/api-v2/#toc-data-types).

This is my first pull request on github, so let me know if I did something wrong ;)
